### PR TITLE
SensorETA WeatherXM Infrastructure Grant Proposals per country

### DIFF
--- a/applications/SensorETA-WeatherXM-Infrastructure-Grant-Proposals/IoT_Working_Group_Jamaica_Grant_Application.md
+++ b/applications/SensorETA-WeatherXM-Infrastructure-Grant-Proposals/IoT_Working_Group_Jamaica_Grant_Application.md
@@ -1,0 +1,82 @@
+# Grant Application
+
+## Project Title
+**WeatherXM stations infrastructure and training - Jamaica**
+
+## Applicant Information
+- **Name**: Larry Ketchersid
+- **Organization**: SensorETA, Inc.
+- **Email**: larry@sensoreta.com
+- **GitHub Username**: lk-sensoreta
+- **Discord Username**: lketchersid
+
+## Grant Request Summary
+This grant request is for hotspots, infrastructure and training to support the deployment of WeatherXM stations in the Caribbean country of Jamaica as part of the WeatherXM+Swissborg deployment project. 
+
+Total for the grant request is $28,000.
+
+## Project Overview
+WeatherXM, with funding from VC Swissborg, is rolling out 2,300+ weather stations. Many of these (700+) are the Helium version of their weather stations. The goal of the project is to provide coverage to “underserved areas. Therefore, most of these are in areas where there is no current LoRaWAN (or Helium) coverage, as well as a lack of weather data.
+
+28 of these weather stations have been delivered to Jamaica with 50 more in transit as of this writing.
+
+SensorETA is working with one organization in Jamaica that (1) wants to create a hurricane and tropical weather network for the island, (2) are farmers and will deploy stations in agricultural areas as well, and (3) are trained telecommunications technicians. With LoRaWAN soil, CO2 and WeatherXM stations, we are working with these organization to not only help them with these agriculture projects but laying the groundwork of a foundation for carbon credits.
+
+One of the most common comments in the Helium IoT Working Group weekly calls and Discord is the need to increase usage of the network.
+
+The most straightforward project to increase usage of the network, while also increasing the worldwide footprint of the network and the education and understanding of Helium IoT is to do anything and everything to support this rollout of WeatherXM stations.
+
+SensorETA is the lead partner with WeatherXM on this rollout. SensorETA has a layered approach to its enterprise IoT solution implementations, building as needed from the network up to and including utilizing sensor data to help build the case for carbon credits for our implementation partners. SensorETA is the IoT partner for carbon credit companies like Arva Intelligence, helping that company build on its leading carbon credit machine learning algorithms with targeted sensor data.
+
+In Jamaica, SensorETA's partner is:
+- Electronic Technicians Training Limited (ETTI) (https://ettlonline.com), a communications technology company based in Jamaica. ETTI is led by Ruel Waine Corniffe who has setup and climbed most of the cell towers in Jamaica. Ruel’s team is motivated by recent weather events effecting the island and impacting the agricultural output. 
+
+Many of our in-country partners that are targeted for weather stations have pushed back on the Helium version, requesting WiFi version instead. This is mainly due to (1) funding for hotspots, in most cases off-grid hotspots; (2) lack of technical knowledge of Helium or LoRaWAN. This grant request is to address both hurdles.
+
+For these IoT working group proposals, each country's deployment and the in-country projects that the deployment will support and nurture are separated into separate proposals.
+
+## Project Goals and Objectives
+- Increase the footprint of and usage of the Helium IoT network by providing hotspots and other infrastructure in support of the rollout of Helium IoT-based WeatherXM Weather stations.
+-- Each station sends a 40-byte packet every three minutes, which, at 2 DC per packet, amounts to 960 DC per day, plus an additional set of packets totaling around 200 to 400 bytes daily.
+-- The last time Leo from WeatherXM calculated WeatherXM's total DC usage a couple of months ago, it stood at roughly 18% of the Helium network’s total, based on 1,871 active stations, excluding those 200 to 400 bytes per day. WeatherXM has since increased to 2,205 active stations, and the additional 700 devices in this current WeatherXM+Swissborg project will likely raise the overall usage by around 30%, pushing WeatherXM's share to more than 25% of the network’s total DC consumption. 
+- Spread knowledge and ensure proper installations of the Helium IoT network by providing network testing devices such as GLAMOS to in-country deployers and distributing access to training materials.
+- Increase visibility and viability of the Helium IoT network through joint marketing with WeatherXM, SensorETA and other deployers.
+- Incentivize and empower local teams by explaining and demonstrating earning crypto through DePIN infrastructure (HNT, WXM, others)
+
+## Proposed Solution
+- Providing funding for off-grid hotspots. Many of these implementations will be agricultural and will need solar power. This could include the “dual-miner” hotspots to support the Sourceful Energy network to provide further local incentives.
+- Providing funding for GLAMOS devices (to enable technical knowledge and ease of planning).
+- Providing training and education, in the form of kits and/or online training similar to the “Helium Hacks” training programs of the past to ensure that local partners understand the Helium technology and are empowered to install and maintain equipment effectively.
+
+## Timeline and Milestones
+Weather stations have already been shipped and received.
+
+| Milestone | Description | Expected Completion Date |
+| --------- | ----------- | ------------------------ |
+| Milestone 1 | Procure and Ship Hotspots, Testing Devices, Kits | Day of Funding |
+| Milestone 2 | Training | On-going and already occurring |
+| Milestone 3 | Initial Hotspot and Weather Station installation | Milestone 2 + 1 week |
+| Milestone 4 | Final Hotspot and Weather Station installation | Milestone 3 + 4 weeks |
+| Milestone 5 | Case Study and Marketing for in-country partners | Milestone 3 + 4 weeks |
+
+## KPIs / Metrics
+
+Through each milestone, the project team will provide metrics on:
+- Number of weather stations deployed
+- Number of hotspots installed
+- Amount of data transmitted over the Helium Network
+- Number of local community members trained on Helium technology
+
+## Budget
+
+| Item | Cost |
+| ---- | ---- |
+| Off-grid hotspots (hotspot, antenna, solar, backhaul) (qty 15) | $22,500 | 
+| Testing Devices (qty 3) | $600 |
+| IoT Education Kits and Courses (qty 3) | $750 |
+| Shipping and Customs Fees (est 20%) | $3,240
+
+## Additional Information
+A use case article for a similar deployment in the Xochimilco area of Mexico can be seen at https://www.sensoreta.com/wxmxochimilco.
+
+---

--- a/applications/SensorETA-WeatherXM-Infrastructure-Grant-Proposals/IoT_Working_Group_Kenya_Grant_Application.md
+++ b/applications/SensorETA-WeatherXM-Infrastructure-Grant-Proposals/IoT_Working_Group_Kenya_Grant_Application.md
@@ -1,0 +1,81 @@
+# Grant Application
+
+## Project Title
+**WeatherXM stations infrastructure and training - Kenya**
+
+## Applicant Information
+- **Name**: Larry Ketchersid
+- **Organization**: SensorETA, Inc.
+- **Email**: larry@sensoreta.com
+- **GitHub Username**: lk-sensoreta
+- **Discord Username**: lketchersid
+
+## Grant Request Summary
+This grant request is for hotspots, infrastructure and training to support the deployment of WeatherXM stations in the African country of Kenya as part of the WeatherXM+Swissborg deployment project. 
+
+Total for the grant request is $20,000.
+
+## Project Overview
+WeatherXM, with funding from VC Swissborg, is rolling out 2,300+ weather stations. Many of these (700+) are the Helium version of their weather stations. The goal of the project is to provide coverage to “underserved areas. Therefore, most of these are in areas where there is no current LoRaWAN (or Helium) coverage, as well as a lack of weather data.
+
+20 of these weather stations have been delivered to Kenya.
+
+Using LoRaWAN sensors on the new EU868 frequency, SensorETA and their partners OPEN (One Planet Education Network), are working with two organizations in Kenya that (1) have created a living lab for different rice strains using regenerative agricultural solutions, (2) have worked with women-owned farms on this same practices, and (3) have worked with the Forestry Training Institute towards reforestation will expand the Helium network in this country to support the WeatherXM station rollout. With LoRaWAN soil, CO2 and WeatherXM stations, we are working with the non-profits there to not only help them with these agriculture projects but laying the groundwork of a foundation for carbon credits.
+
+One of the most common comments in the Helium IoT Working Group weekly calls and Discord is the need to increase usage of the network.
+
+The most straightforward project to increase usage of the network, while also increasing the worldwide footprint of the network and the education and understanding of Helium IoT is to do anything and everything to support this rollout of WeatherXM stations.
+
+SensorETA is the lead partner with WeatherXM on this rollout. SensorETA has a layered approach to its enterprise IoT solution implementations, building as needed from the network up to and including utilizing sensor data to help build the case for carbon credits for our implementation partners. SensorETA is the IoT partner for carbon credit companies like Arva Intelligence, helping that company build on its leading carbon credit machine learning algorithms with targeted sensor data.
+
+In Kenya, SensorETA's partner is One Plant Education Network (OPEN) and two separate schools: the Bukokholo R.C Primary School in Bungoma, and the Majoreni Secondary School in Lungalunga. Bonaventure Masika and Alex Polycap, the contacts at these two schools, will utilize the weather stations and the Helium to teach technology in lock step with regenerative agricultural methods.
+
+Many of our in-country partners that are targeted for weather stations have pushed back on the Helium version, requesting WiFi version instead. This is mainly due to (1) funding for hotspots, in most cases off-grid hotspots; (2) lack of technical knowledge of Helium or LoRaWAN. This grant request is to address both hurdles.
+
+For these IoT working group proposals, each country's deployment and the in-country projects that the deployment will support and nurture are separated into separate proposals.
+
+## Project Goals and Objectives
+- Increase the footprint of and usage of the Helium IoT network by providing hotspots and other infrastructure in support of the rollout of Helium IoT-based WeatherXM Weather stations. This includes building on the recent EU-868 standardization in Africa for rollouts in those countries.
+-- Each station sends a 40-byte packet every three minutes, which, at 2 DC per packet, amounts to 960 DC per day, plus an additional set of packets totaling around 200 to 400 bytes daily.
+-- The last time Leo from WeatherXM calculated WeatherXM's total DC usage a couple of months ago, it stood at roughly 18% of the Helium network’s total, based on 1,871 active stations, excluding those 200 to 400 bytes per day. WeatherXM has since increased to 2,205 active stations, and the additional 700 devices in this current WeatherXM+Swissborg project will likely raise the overall usage by around 30%, pushing WeatherXM's share to more than 25% of the network’s total DC consumption. 
+- Spread knowledge and ensure proper installations of the Helium IoT network by providing network testing devices such as GLAMOS to in-country deployers and distributing access to training materials.
+- Increase visibility and viability of the Helium IoT network through joint marketing with WeatherXM, SensorETA and other deployers.
+- Incentivize and empower local teams by explaining and demonstrating earning crypto through DePIN infrastructure (HNT, WXM, Sourceful (where applicable),others)
+
+## Proposed Solution
+- Providing funding for off-grid hotspots. Many of these implementations will be agricultural and will need solar power. This could include the “dual-miner” hotspots to support the Sourceful Energy network to provide further local incentives.
+- Providing funding for GLAMOS devices (to enable technical knowledge and ease of planning).
+- Providing training and education, in the form of kits and/or online training similar to the “Helium Hacks” training programs of the past to ensure that local partners understand the Helium technology and are empowered to install and maintain equipment effectively.
+
+## Timeline and Milestones
+Weather stations have already been shipped and received.
+
+| Milestone | Description | Expected Completion Date |
+| --------- | ----------- | ------------------------ |
+| Milestone 1 | Procure and Ship Hotspots, Testing Devices, Kits | Day of Funding |
+| Milestone 2 | Training | On-going and already occurring |
+| Milestone 3 | Initial Hotspot and Weather Station installation | Milestone 2 + 1 week |
+| Milestone 4 | Final Hotspot and Weather Station installation | Milestone 3 + 4 weeks |
+| Milestone 5 | Case Study and Marketing for in-country partners | Milestone 3 + 4 weeks |
+
+## KPIs / Metrics
+
+Through each milestone, the project team will provide metrics on:
+- Number of weather stations deployed
+- Number of hotspots installed
+- Amount of data transmitted over the Helium Network
+- Number of local community members trained on Helium technology
+
+## Budget
+
+| Item | Cost |
+| ---- | ---- |
+| Off-grid hotspots (hotspot, antenna, solar, backhaul) (qty 10) | $15,000 | 
+| Testing Devices (qty 3) | $600 |
+| IoT Education Kits and Courses (qty 3) | $750 |
+| Shipping and Customs Fees (est 20%) | $3,240
+
+## Additional Information
+A use case article for a similar deployment in the Xochimilco area of Mexico can be seen at https://www.sensoreta.com/wxmxochimilco.
+
+---

--- a/applications/SensorETA-WeatherXM-Infrastructure-Grant-Proposals/IoT_Working_Group_Liberia_Grant_Application.md
+++ b/applications/SensorETA-WeatherXM-Infrastructure-Grant-Proposals/IoT_Working_Group_Liberia_Grant_Application.md
@@ -1,0 +1,83 @@
+# Grant Application
+
+## Project Title
+**WeatherXM stations infrastructure and training - Liberia**
+
+## Applicant Information
+- **Name**: Larry Ketchersid
+- **Organization**: SensorETA, Inc.
+- **Email**: larry@sensoreta.com
+- **GitHub Username**: lk-sensoreta
+- **Discord Username**: lketchersid
+
+## Grant Request Summary
+This grant request is for hotspots, infrastructure and training to support the deployment of WeatherXM stations in the African country of Liberia as part of the WeatherXM+Swissborg deployment project. 
+
+Total for the grant request is $20,000.
+
+## Project Overview
+WeatherXM, with funding from VC Swissborg, is rolling out 2,300+ weather stations. Many of these (700+) are the Helium version of their weather stations. The goal of the project is to provide coverage to “underserved areas. Therefore, most of these are in areas where there is no current LoRaWAN (or Helium) coverage, as well as a lack of weather data.
+
+50 of these weather stations have been delivered to Liberia. with two already installed as of this writing.
+
+Using LoRaWAN sensors on the new EU868 frequency, SensorETA and their partners OPEN (One Planet Education Network), are working with two organizations in Liberia that (1) have created a living lab for different rice strains using regenerative agricultural solutions, (2) have worked with women-owned farms on this same practices, and (3) have worked with the Forestry Training Institute towards reforestation will expand the Helium network in this country to support the WeatherXM station rollout. With LoRaWAN soil, CO2 and WeatherXM stations, we are working with the non-profits there to not only help them with these agriculture projects but laying the groundwork of a foundation for carbon credits.
+
+One of the most common comments in the Helium IoT Working Group weekly calls and Discord is the need to increase usage of the network.
+
+The most straightforward project to increase usage of the network, while also increasing the worldwide footprint of the network and the education and understanding of Helium IoT is to do anything and everything to support this rollout of WeatherXM stations.
+
+SensorETA is the lead partner with WeatherXM on this rollout. SensorETA has a layered approach to its enterprise IoT solution implementations, building as needed from the network up to and including utilizing sensor data to help build the case for carbon credits for our implementation partners. SensorETA is the IoT partner for carbon credit companies like Arva Intelligence, helping that company build on its leading carbon credit machine learning algorithms with targeted sensor data.
+
+In Liberia, SensorETA's partners include:
+- Panta Pride (https://www.pantapride.org), a non-profit based in the Panta and Zota regions of the country. Panta has built roads, rice banks, and other infrastructure for its community. Sensors and weather stations will be deployed in the rice farms and rubber tree farms, working with them as they experiment with particular rice strains and move toward carbon credits for the regenerative agricultural practices. Panta also works with women-owned farms in the community and some of these will be the recipients of weather stations. This is a link to a recent article about Panta Pride’s efforts (https://www.liberianobserver.com/news/panta-pride-concludes-successful-thanksgiving-program-in-bong/article_5d451a4e-a559-11ef-9496-3f58905635eb.html)
+- One Plant Education Network (OPEN) and the Liberia Forestry Training Institute. Reforestation in Liberia has been a large achievement since the two Liberian civil wars. Adding sensors to gather data in these forests is a major goal for the FTI.
+
+Many of our in-country partners that are targeted for weather stations have pushed back on the Helium version, requesting WiFi version instead. This is mainly due to (1) funding for hotspots, in most cases off-grid hotspots; (2) lack of technical knowledge of Helium or LoRaWAN. This grant request is to address both hurdles.
+
+For these IoT working group proposals, each country's deployment and the in-country projects that the deployment will support and nurture are separated into separate proposals.
+
+## Project Goals and Objectives
+- Increase the footprint of and usage of the Helium IoT network by providing hotspots and other infrastructure in support of the rollout of Helium IoT-based WeatherXM Weather stations. This includes building on the recent EU-868 standardization in Africa for rollouts in those countries.
+-- Each station sends a 40-byte packet every three minutes, which, at 2 DC per packet, amounts to 960 DC per day, plus an additional set of packets totaling around 200 to 400 bytes daily.
+-- The last time Leo from WeatherXM calculated WeatherXM's total DC usage a couple of months ago, it stood at roughly 18% of the Helium network’s total, based on 1,871 active stations, excluding those 200 to 400 bytes per day. WeatherXM has since increased to 2,205 active stations, and the additional 700 devices in this current WeatherXM+Swissborg project will likely raise the overall usage by around 30%, pushing WeatherXM's share to more than 25% of the network’s total DC consumption. 
+- Spread knowledge and ensure proper installations of the Helium IoT network by providing network testing devices such as GLAMOS to in-country deployers and distributing access to training materials.
+- Increase visibility and viability of the Helium IoT network through joint marketing with WeatherXM, SensorETA and other deployers.
+- Incentivize and empower local teams by explaining and demonstrating earning crypto through DePIN infrastructure (HNT, WXM, Sourceful (where applicable),others)
+
+## Proposed Solution
+- Providing funding for off-grid hotspots. Many of these implementations will be agricultural and will need solar power. This could include the “dual-miner” hotspots to support the Sourceful Energy network to provide further local incentives.
+- Providing funding for GLAMOS devices (to enable technical knowledge and ease of planning).
+- Providing training and education, in the form of kits and/or online training similar to the “Helium Hacks” training programs of the past to ensure that local partners understand the Helium technology and are empowered to install and maintain equipment effectively.
+
+## Timeline and Milestones
+Weather stations have already been shipped and received.
+
+| Milestone | Description | Expected Completion Date |
+| --------- | ----------- | ------------------------ |
+| Milestone 1 | Procure and Ship Hotspots, Testing Devices, Kits | Day of Funding |
+| Milestone 2 | Training | On-going and already occurring |
+| Milestone 3 | Initial Hotspot and Weather Station installation | Milestone 2 + 1 week |
+| Milestone 4 | Final Hotspot and Weather Station installation | Milestone 3 + 4 weeks |
+| Milestone 5 | Case Study and Marketing for in-country partners | Milestone 3 + 4 weeks |
+
+## KPIs / Metrics
+
+Through each milestone, the project team will provide metrics on:
+- Number of weather stations deployed
+- Number of hotspots installed
+- Amount of data transmitted over the Helium Network
+- Number of local community members trained on Helium technology
+
+## Budget
+
+| Item | Cost |
+| ---- | ---- |
+| Off-grid hotspots (hotspot, antenna, solar, backhaul) (qty 10) | $15,000 | 
+| Testing Devices (qty 3) | $600 |
+| IoT Education Kits and Courses (qty 3) | $750 |
+| Shipping and Customs Fees (est 20%) | $3,240
+
+## Additional Information
+A use case article for a similar deployment in the Xochimilco area of Mexico can be seen at https://www.sensoreta.com/wxmxochimilco.
+
+---

--- a/applications/SensorETA-WeatherXM-Infrastructure-Grant-Proposals/IoT_Working_Group_Venezuela_Grant_Application.md
+++ b/applications/SensorETA-WeatherXM-Infrastructure-Grant-Proposals/IoT_Working_Group_Venezuela_Grant_Application.md
@@ -1,0 +1,83 @@
+# Grant Application
+
+## Project Title
+**WeatherXM stations infrastructure and training - Venezuela**
+
+## Applicant Information
+- **Name**: Larry Ketchersid
+- **Organization**: SensorETA, Inc.
+- **Email**: larry@sensoreta.com
+- **GitHub Username**: lk-sensoreta
+- **Discord Username**: lketchersid
+
+## Grant Request Summary
+This grant request is for hotspots, infrastructure and training to support the deployment of WeatherXM stations in the South America country of Venezuela as part of the WeatherXM+Swissborg deployment project. 
+
+Total for the grant request is $92,000.
+
+## Project Overview
+WeatherXM, with funding from VC Swissborg, is rolling out 2,300+ weather stations. Many of these (700+) are the Helium version of their weather stations. The goal of the project is to provide coverage to “underserved areas. Therefore, most of these are in areas where there is no current LoRaWAN (or Helium) coverage, as well as a lack of weather data.
+
+260 of these weather stations have been delivered to Venezuela. with two already installed as of this writing.
+
+SensorETA is working with two organizations in Venezuela that (1) have created a blockchain university program to which we will contribute training and knowledge on DePIN, LoRaWAN, Helium and weather, and (2) have coffee and cocoa farms that would benefit from not only hyper-local weather but other agriculture sensors for monitoring and automation. With LoRaWAN soil, CO2 and WeatherXM stations, we are working with these organization to not only help them with these agriculture projects but laying the groundwork of a foundation for carbon credits.
+
+One of the most common comments in the Helium IoT Working Group weekly calls and Discord is the need to increase usage of the network.
+
+The most straightforward project to increase usage of the network, while also increasing the worldwide footprint of the network and the education and understanding of Helium IoT is to do anything and everything to support this rollout of WeatherXM stations.
+
+SensorETA is the lead partner with WeatherXM on this rollout. SensorETA has a layered approach to its enterprise IoT solution implementations, building as needed from the network up to and including utilizing sensor data to help build the case for carbon credits for our implementation partners. SensorETA is the IoT partner for carbon credit companies like Arva Intelligence, helping that company build on its leading carbon credit machine learning algorithms with targeted sensor data.
+
+In Venezuela, SensorETA's partners include:
+- UNETI (https://www.uneti.edu.ve), a technology university based in Caracas. UNETI has a leading edge program educating students on blockchain. Its labs include blockchain miners for many different chains, and utilize some of these earnings to pay professors. The school Dean, Dr. Carlos Bebeci, is excited about the weather station and Helium deployments, and will use it as a program for the students. 
+- Café Venezuela. Venezuelans believe their coffee and cocoa rival any in the world. The farmers desire a hyperlocal weather network which they can use to not only improve the quality of their crops, but put online for customers to view.
+
+Many of our in-country partners that are targeted for weather stations have pushed back on the Helium version, requesting WiFi version instead. This is mainly due to (1) funding for hotspots, in most cases off-grid hotspots; (2) lack of technical knowledge of Helium or LoRaWAN. This grant request is to address both hurdles.
+
+For these IoT working group proposals, each country's deployment and the in-country projects that the deployment will support and nurture are separated into separate proposals.
+
+## Project Goals and Objectives
+- Increase the footprint of and usage of the Helium IoT network by providing hotspots and other infrastructure in support of the rollout of Helium IoT-based WeatherXM Weather stations.
+-- Each station sends a 40-byte packet every three minutes, which, at 2 DC per packet, amounts to 960 DC per day, plus an additional set of packets totaling around 200 to 400 bytes daily.
+-- The last time Leo from WeatherXM calculated WeatherXM's total DC usage a couple of months ago, it stood at roughly 18% of the Helium network’s total, based on 1,871 active stations, excluding those 200 to 400 bytes per day. WeatherXM has since increased to 2,205 active stations, and the additional 700 devices in this current WeatherXM+Swissborg project will likely raise the overall usage by around 30%, pushing WeatherXM's share to more than 25% of the network’s total DC consumption. 
+- Spread knowledge and ensure proper installations of the Helium IoT network by providing network testing devices such as GLAMOS to in-country deployers and distributing access to training materials.
+- Increase visibility and viability of the Helium IoT network through joint marketing with WeatherXM, SensorETA and other deployers.
+- Incentivize and empower local teams by explaining and demonstrating earning crypto through DePIN infrastructure (HNT, WXM, others)
+
+## Proposed Solution
+- Providing funding for off-grid hotspots. Many of these implementations will be agricultural and will need solar power. This could include the “dual-miner” hotspots to support the Sourceful Energy network to provide further local incentives.
+- Providing funding for GLAMOS devices (to enable technical knowledge and ease of planning).
+- Providing training and education, in the form of kits and/or online training similar to the “Helium Hacks” training programs of the past to ensure that local partners understand the Helium technology and are empowered to install and maintain equipment effectively.
+
+## Timeline and Milestones
+Weather stations have already been shipped and received.
+
+| Milestone | Description | Expected Completion Date |
+| --------- | ----------- | ------------------------ |
+| Milestone 1 | Procure and Ship Hotspots, Testing Devices, Kits | Day of Funding |
+| Milestone 2 | Training | On-going and already occurring |
+| Milestone 3 | Initial Hotspot and Weather Station installation | Milestone 2 + 1 week |
+| Milestone 4 | Final Hotspot and Weather Station installation | Milestone 3 + 12 weeks |
+| Milestone 5 | Case Study and Marketing for in-country partners | Milestone 3 + 8 weeks |
+
+## KPIs / Metrics
+
+Through each milestone, the project team will provide metrics on:
+- Number of weather stations deployed
+- Number of hotspots installed
+- Amount of data transmitted over the Helium Network
+- Number of local community members trained on Helium technology
+
+## Budget
+
+| Item | Cost |
+| ---- | ---- |
+| Off-grid hotspots (hotspot, antenna, solar, backhaul) (qty 50) | $75,000 | 
+| Testing Devices (qty 3) | $600 |
+| IoT Education Kits and Courses (qty 3) | $750 |
+| Shipping and Customs Fees (est 20%) | $15,270
+
+## Additional Information
+A use case article for a similar deployment in the Xochimilco area of Mexico can be seen at https://www.sensoreta.com/wxmxochimilco.
+
+---


### PR DESCRIPTION
This directory includes four grant proposals that have very similar formats. Each of them are in support of the WeatherXM+Swissborg project rolling out WeatherXM stations to underserved areas. Of the 2,700+ weather stations, approximately 700 are the Helium versions.

These four requests are for off-grid hotspots, testing devices (GLAMOS) and training materials to build the Helium IoT knowledge and infrastructure in Liberia, Venezuela, Jamaica and Kenya. This would not only enable the rollout of the WeatherXM stations, but increase traffic on the network, train in-country teams on Helium, IoT, DePIN and other essentials, and provide multiple diverse use cases.

These are split by country in order to have granularity for the IoT working group. There are several other countries that Helium weather stations are being rolled out to. Happy to discuss others if desired.